### PR TITLE
Removing Current limitation of using hosts CA and allow usage of private Root CA's

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The hosts file is simply a single `hostname:port` per line. Empty lines or lines
 Current limitations:
 --------------------
 
-* This uses the host's root CA set to check the validity of certificates.  This means that it is not able to validate things like self-signed certificates.
 * A certificate must be valid for it to be checked.
 
 License:
@@ -27,13 +26,13 @@ Copyright (c) 2013, Ryan Rogers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/src/check-certs/check-certs.go
+++ b/src/check-certs/check-certs.go
@@ -67,6 +67,8 @@ var (
 	warnDays    = flag.Int("days", 0, "Warn if the certificate will expire within this many days.")
 	checkSigAlg = flag.Bool("check-sig-alg", true, "Verify that non-root certificates are using a good signature algorithm.")
 	concurrency = flag.Int("concurrency", defaultConcurrency, "Maximum number of hosts to check at once.")
+	rootCAsfile = flag.String("rootca", "", "The path to the file containing addtional RootCAs to include.")
+	config      = tls.Config{}
 )
 
 type certErrors struct {
@@ -81,11 +83,32 @@ type hostResult struct {
 }
 
 func main() {
+
+	// Load the Root CA's from trusted 3rd party Vendors
+	certPool, err := gocertifi.CACerts()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	flag.Parse()
 
 	if len(*hostsFile) == 0 {
 		flag.Usage()
 		return
+	}
+
+	if len(*rootCAsfile) == 0 {
+		config = tls.Config{RootCAs: certPool}
+	} else {
+		rootCAs, err := ioutil.ReadFile(*rootCAsfile)
+
+		if err != nil {
+			log.Printf("Couldn't load file %v", err)
+			return
+		}
+		certPool.AppendCertsFromPEM(rootCAs)
+		config = tls.Config{RootCAs: certPool}
 	}
 	if *warnYears < 0 {
 		*warnYears = 0
@@ -179,21 +202,6 @@ func checkHost(host string) (result hostResult) {
 		host:  host,
 		certs: []certErrors{},
 	}
-
-	// Load the cacerts for trusted authorities
-	cert_pool, err := gocertifi.CACerts()
-
-	rootCAs, err := ioutil.ReadFile("rootCAs")
-
-	if err != nil {
-		log.Printf("Couldn't load file %v", err)
-		return
-	}
-
-	// Load the private root certificates (if any)
-	cert_pool.AppendCertsFromPEM(rootCAs)
-
-	config := tls.Config{RootCAs: cert_pool}
 
 	conn, err := tls.Dial("tcp", host, &config)
 	if err != nil {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -1,0 +1,11 @@
+{
+	"version": 0,
+	"dependencies": [
+		{
+			"importpath": "github.com/certifi/gocertifi",
+			"repository": "https://github.com/certifi/gocertifi",
+			"revision": "3fd9e1adb12b72d2f3f82191d49be9b93c69f67c",
+			"branch": "master"
+		}
+	]
+}


### PR DESCRIPTION
Thank you for this code. I'm working on improving my go tooling and this has helped me a ton. I have added the ability to provide a file with additional Root CA's for private root Certificates / private authorities.